### PR TITLE
added current user ID to response

### DIFF
--- a/API/DatabaseManagement.cjs
+++ b/API/DatabaseManagement.cjs
@@ -381,7 +381,7 @@ app.get("/loadUsers",
         `SELECT ID, email FROM users WHERE deleted = false`
       );
 
-      res.status(200).json({ "success": true , "data" : dataList})
+      res.status(200).json({ "success": true, "data": dataList, "currentUserID": targetID})
 
     } catch (error) {
       console.log(error)


### PR DESCRIPTION
Added current user ID to the response so the front-end can compare the current ID of the logged in user to the ID of the selected user to be deleted. This is to check if the current logged in user is deleting their own account or not.